### PR TITLE
Escape slashes in git revision

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ macro (Git_GET_REVISION dir variable)
                   WORKING_DIRECTORY ${dir}
                   OUTPUT_VARIABLE GIT_COMMIT_HASH
                   OUTPUT_STRIP_TRAILING_WHITESPACE)
+  string (REPLACE "/" "_" GIT_BRANCH ${GIT_BRANCH})
   set (${variable} "${GIT_COMMIT_HASH}-${GIT_BRANCH}")
 endmacro (Git_GET_REVISION)
 


### PR DESCRIPTION
When working with a pull request the git revision returned by the
command `git rev-parse --abbrev-ref HEAD` will return something like
`pull/1234` as the branch name.

Using revision strings containing slashes result in build failures since
the string is used for the `.so` files, leading to file names ending
ending in `~git-1a2b3c4-pull/1234` passed as output files to the linker
which interprets the slash as a separator and attempts to write to a
non-existent directory.

This commit replaces any slashes with underscores, resulting in a suffix
like `pull_1234` instead.