### PR TITLE
Return struct pointer in wmi_connect*().

### DIFF
--- a/wmi/openvas_wmi_interface.h
+++ b/wmi/openvas_wmi_interface.h
@@ -35,19 +35,24 @@
 #ifndef _NASL_OPENVAS_WMI_INTERFACE_H
 #define _NASL_OPENVAS_WMI_INTERFACE_H
 
-typedef int WMI_HANDLE;
+typedef struct IWbemServices * WMI_HANDLE;
 
 char *wmi_versioninfo ();
-int wmi_connect(int argc, char **argv, WMI_HANDLE * handle);
-//int wmi_connect (const char *, const char *, const char *, const char *,
-//                 WMI_HANDLE *);
+
+WMI_HANDLE
+wmi_connect (int, char **);
+
 int wmi_close (WMI_HANDLE);
 int wmi_query (WMI_HANDLE, const char *, char **);
 
-int wmi_connect_rsop(int argc, char **argv, WMI_HANDLE * handle);
+WMI_HANDLE
+wmi_connect_rsop (int, char **);
+
 int wmi_query_rsop (WMI_HANDLE, const char *, char **);
 
-int wmi_connect_reg(int argc, char **argv, WMI_HANDLE * handle);
+WMI_HANDLE
+wmi_connect_reg (int, char **);
+
 int wmi_reg_get_sz (WMI_HANDLE, unsigned int, const char *, const char *,
                     char **);
 int wmi_reg_enum_value (WMI_HANDLE, unsigned int, const char *, char **);

--- a/wmi/wmicso.c
+++ b/wmi/wmicso.c
@@ -191,20 +191,14 @@ wmi_versioninfo()
 /**
  * @brief Estiablish connection to a WMI service.
  *
- * @param[in] username - The username for getting access to WMI service
+ * @param[in] argc      Number wmic of arguments.
  *
- * @param[in] password - The password that corresponds to username
+ * @param[in] argv      Array of wmic arguments.
  *
- * @param[in] host - The host system to connect to
- *
- * @param[in] namespace - The WMI namespace of the service.
- *
- * @param[out] handle - A connection handle in case of success.
- *
- * @return, 0 on success, -1 on failure
+ * @return, WMI_HANDLE on success, NULL on failure.
  */
-
-int wmi_connect(int argc, char **argv, WMI_HANDLE *handle)
+WMI_HANDLE
+wmi_connect (int argc, char **argv)
 {
 
   WERROR result;
@@ -219,7 +213,7 @@ int wmi_connect(int argc, char **argv, WMI_HANDLE *handle)
   if(ret == 1)
   {
     DEBUG(1, ("ERROR: %s\n", "Invalid input arguments"));
-    return -1;
+    return NULL;
   }
 
   dcerpc_init();
@@ -238,13 +232,12 @@ int wmi_connect(int argc, char **argv, WMI_HANDLE *handle)
 
   result = WBEM_ConnectServer(ctx, args.hostname, args.ns, 0, 0, 0, 0, 0, 0, &pWS);
   WERR_CHECK("Login to remote object.\n");
-  *handle = (WMI_HANDLE) pWS;
-  return 0;
+  return pWS;
 
 error:
   status = werror_to_ntstatus(result);
   DEBUG(3, ("NTSTATUS: %s - %s\n", nt_errstr(status), get_friendly_nt_error_msg(status)));
-  return -1;
+  return NULL;
 }
 
 

--- a/wmi/wmireg.c
+++ b/wmi/wmireg.c
@@ -118,19 +118,14 @@ static int parse_args(int argc, char *argv[], struct program_args *pmyargs)
 /**
  * @brief Estiablish connection to a WMI Registry service.
  *
- * @param[in] username - The username for getting access to WMI service
+ * @param[in] argc      Number wmic of arguments.
  *
- * @param[in] password - The password that corresponds to username
+ * @param[in] argv      Array of wmic arguments.
  *
- * @param[in] host - The host system to connect to
- *
- * @param[in] namespace - The WMI namespace of the service.
- *
- * @param[out] handle - A connection handle in case of success.
- *
- * @return, 0 on success, -1 on failure
+ * @return, WMI_HANDLE on success, NULL on failure.
  */
-int wmi_connect_reg(int argc, char **argv, WMI_HANDLE *handle)
+WMI_HANDLE
+wmi_connect_reg (int argc, char **argv)
 {
   WERROR result;
   NTSTATUS status;
@@ -144,7 +139,7 @@ int wmi_connect_reg(int argc, char **argv, WMI_HANDLE *handle)
   if(ret == 1)
   {
     DEBUG(1, ("ERROR: %s\n", "Invalid input arguments"));
-    return -1;
+    return NULL;
   }
 
   dcerpc_init();
@@ -164,14 +159,12 @@ int wmi_connect_reg(int argc, char **argv, WMI_HANDLE *handle)
 
   result = WBEM_ConnectServer(ctx, args.hostname, "root\\default", 0, 0, 0, 0, 0, 0, &pWS);
   WERR_CHECK("Login to remote object.\n");
-  *handle = (WMI_HANDLE) pWS;
-
-  return 0;
+  return pWS;
 
 error:
   status = werror_to_ntstatus(result);
   DEBUG(3, ("NTSTATUS: %s - %s\n", nt_errstr(status), get_friendly_nt_error_msg(status)));
-  return -1;
+  return NULL;
 }
 
 

--- a/wmi/wmirsop.c
+++ b/wmi/wmirsop.c
@@ -118,20 +118,14 @@ static int parse_args(int argc, char *argv[], struct program_args *pmyargs)
 /**
  * @brief Estiablish connection to a WMI RSOP service.
  *
- * @param[in] username - The username for getting access to WMI service
+ * @param[in] argc      Number wmic of arguments.
  *
- * @param[in] password - The password that corresponds to username
+ * @param[in] argv      Array of wmic arguments.
  *
- * @param[in] host - The host system to connect to
- *
- * @param[in] namespace - The WMI namespace of the service.
- *
- * @param[out] handle - A connection handle in case of success.
- *
- * @return, 0 on success, -1 on failure
+ * @return, WMI_HANDLE on success, NULL on failure.
  */
-
-int wmi_connect_rsop(int argc, char **argv, WMI_HANDLE *handle)
+WMI_HANDLE
+wmi_connect_rsop (int argc, char **argv)
 {
   /*Works only for domain based systems and not for WORKGROUP */
 
@@ -154,7 +148,7 @@ int wmi_connect_rsop(int argc, char **argv, WMI_HANDLE *handle)
   if(ret == 1)
   {
     DEBUG(1, ("ERROR: %s\n", "Invalid input arguments"));
-    return -1;
+    return NULL;
   }
 
 
@@ -209,13 +203,12 @@ int wmi_connect_rsop(int argc, char **argv, WMI_HANDLE *handle)
   namespace = talloc_asprintf_append(v.v_string, "%s", "\\computer");
   result = WBEM_ConnectServer(ctx, args.hostname, namespace, 0, 0, 0, 0, 0, 0, &pWS);
 
-  *handle = (WMI_HANDLE) pWS;
-  return 0;
+  return pWS;
 
 error:
   status = werror_to_ntstatus(result);
   DEBUG(3, ("NTSTATUS: %s - %s\n", nt_errstr(status), get_friendly_nt_error_msg(status)));
-  return -1;
+  return NULL;
 }
 
 


### PR DESCRIPTION
Casting the connection struct pointer to an integer may overflow and
thus lead to an erroneous value.