### PR TITLE
Rework README to match template

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,7 +2,7 @@ INSTALLATION INSTRUCTIONS FOR OPENVAS-SMB
 =========================================
 
 Please note: The reference system used by most of the developers is Debian
-GNU/Linux 'Stretch' 9. The build might fail on any other system. Also it is
+GNU/Linux 'Stretch' 9. The build might fail on any other system. Also, it is
 necessary to install dependent development packages.
 
 Prerequisites for openvas-smb
@@ -16,36 +16,38 @@ Prerequisites for openvas-smb
 * libglib2.0-dev
 
 Install prerequisites on Debian GNU/Linux 'Stretch' 9:
-# apt-get install install gcc cmake pkg-config gcc-mingw-w64 libgnutls28-dev \
-  perl-base heimdal-dev libpopt-dev libglib2.0-dev
+
+    apt-get install gcc cmake pkg-config gcc-mingw-w64 libgnutls28-dev \
+                    perl-base heimdal-dev libpopt-dev libglib2.0-dev
 
 Compiling openvas-smb
 ---------------------
 
 Create a build directory and change into it with
 
-    $ mkdir build
-    $ cd build
+    mkdir build
+    cd build
 
 Configure the build with
 
-    $ cmake -DCMAKE_INSTALL_PREFIX=/path/to/your/installation ..
+    cmake -DCMAKE_INSTALL_PREFIX=/path/to/your/installation ..
 
 or (if you want to use the default installation path /usr/local)
 
-    $ cmake ..
+    cmake ..
 
 This only needs to be done once.
 
 Thereafter, the following commands are useful.
 
-    $ make                # build the binaries
-    $ make install        # install the build
-    $ make rebuild_cache  # rebuild the cmake cache
+    make                # build the libraries
+    make doc            # build the documentation
+    make doc-full       # build more developer-oriented documentation
+    make install        # install the build
+    make rebuild_cache  # rebuild the cmake cache
 
-Please note that you may have to execute "make install" as root, especially if
+Please note that you may have to execute `make install` as root, especially if
 you have specified a prefix for which your user does not have full permissions.
 
-To clean up the build environment, simply remove the contents of the "build"
+To clean up the build environment, simply remove the contents of the `build`
 directory you created above.
-

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This module can be configured, built and installed with following commands:
     make install
 
 For detailed installation requirements and instructions, please see the file
-[INSTALL](INSTALL).
+[INSTALL.md](INSTALL.md).
 
 If you are not familiar or comfortable building from source code, we recommend
 that you use the Greenbone Community Edition, a prepared virtual machine with a

--- a/README.md
+++ b/README.md
@@ -1,30 +1,55 @@
-[![CircleCI](https://circleci.com/gh/greenbone/openvas-smb/tree/master.svg?style=svg)](https://circleci.com/gh/greenbone/openvas-smb/tree/master)
+![Greenbone Logo](https://www.greenbone.net/wp-content/uploads/gb_logo_resilience_horizontal.png)
 
 # openvas-smb
 
-This is the smb module for the OpenVAS Scanner. It includes libraries
-(openvas-wmiclient / openvas-wincmd) to interface with Microsoft Windows
-Systems through the Windows Management Instrumentation API and a winexe
+[![GitHub releases](https://img.shields.io/github/release/greenbone/openvas-smb.svg)](https://github.com/greenbone/openvas-smb/releases)
+[![CircleCI](https://circleci.com/gh/greenbone/openvas-smb/tree/master.svg?style=svg)](https://circleci.com/gh/greenbone/openvas-smb/tree/master)
+
+This is the `smb` module for the OpenVAS Scanner. It includes libraries
+(`openvas-wmiclient`/`openvas-wincmd`) to interface with Microsoft Windows
+Systems through the Windows Management Instrumentation API and a `winexe`
 binary to execute processes remotely on that system.
 
-For more information, please refer to http://www.greenbone.net or
-to http://www.openvas.org.
+## Installation
 
-Please see the file COPYING for the license information.
+This module can be configured, built and installed with following commands:
 
-To build and install openvas-smb, please refer to the instructions provided in
-the file INSTALL.  If you are not familiar or comfortable with building from
-source code, we recommend that you use the prepared virtual machine with a
-readily available setup.  Information regarding the virtual machine is available
-at http://www.greenbone.net/en/community-edition/.
+    cmake .
+    make install
 
-An overview on commercial options is available at
-http://www.greenbone.net/en/product-comparison/.
+For detailed installation requirements and instructions, please see the file
+[INSTALL](INSTALL).
 
-You can report bugs to https://github.com/greenbone/openvas-smb/issues
+If you are not familiar or comfortable building from source code, we recommend
+that you use the Greenbone Community Edition, a prepared virtual machine with a
+readily available setup. Information regarding the virtual machine is available
+at <https://www.greenbone.net/en/community-edition/>.
 
+## Support
 
-## History:
+For any question on the usage of `openvas-smb` please use the [Greenbone
+Community Portal](https://community.greenbone.net/c/gse). If you found a
+problem with the software, please [create an
+issue](https://github.com/greenbone/openvas-smb/issues) on GitHub. If you are a
+Greenbone customer you may alternatively or additionally forward your issue to
+the Greenbone Support Portal.
+
+## Maintainer
+
+This project is maintained by [Greenbone Networks GmbH](https://www.greenbone.net/).
+
+## Contributing
+
+Your contributions are highly appreciated. Please [create a pull
+request](https://github.com/greenbone/openvas-smb/pulls) on GitHub. Bigger
+changes need to be discussed with the development team via the [issues section
+at github](https://github.com/greenbone/openvas-smb/issues) first.
+
+## License
+
+Licensed under the [GNU General Public License v2.0 or later](COPYING).
+
+## History
 
 This module is derived from a package distributed by Zenoss, Inc.,
 named wmi-1.3.14. The original location was:


### PR DESCRIPTION
The commits adjust layout and content of the `README` file to match the template provided by the `greenbone/templates` repository. Also, the `INSTALL` file format is switched to Markdown, with an update of relevant sections.

This makes `openvas-smb` consistent with the changes from greenbone/gvm-libs#147.