### PR TITLE
Do not consider as an error when a class is not found.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [20.08.0] (unreleased)
+
+### Changed
+- Let wmi_query and wmi_query_rsop return any error and do not consider it as error when a class is not found.
+  [#26](https://github.com/greenbone/openvas-smb/pull/26)
+
+[20.08.0]: https://github.com/greenbone/openvas-smb/compare/v1.0.5...master

--- a/wmi/wmirsop.c
+++ b/wmi/wmirsop.c
@@ -219,9 +219,10 @@ error:
  *
  * @param[in] query - WQL RSOP query
  *
- * @param[in] val_name - Registry value to be queried
+ * @param[out] res - Result of query as string, or the error.
  *
- * @return, 0 on success, -1 on failure
+ * @return, 0 on success, -1 on failure. If fail and res is filled, res must
+ *          be free'd.
  */
 int wmi_query_rsop(WMI_HANDLE handle, const char *query, char **res)
 {
@@ -253,7 +254,8 @@ int wmi_query_rsop(WMI_HANDLE handle, const char *query, char **res)
     /* WERR_BADFUNC is OK, it means only that there is less returned
      * objects than requested
      */
-    if (!W_ERROR_EQUAL(result, WERR_BADFUNC)){
+    if (!W_ERROR_EQUAL(result, WERR_BADFUNC)
+        && W_ERROR_V(result) != WBEM_E_INVALID_CLASS) {
       WERR_CHECK("Retrieve result data.");
     }
     else{
@@ -286,5 +288,7 @@ int wmi_query_rsop(WMI_HANDLE handle, const char *query, char **res)
 error:
   status = werror_to_ntstatus(result);
   DEBUG(3, ("NTSTATUS: %s - %s\n", nt_errstr(status), get_friendly_nt_error_msg(status)));
+  *res = strdup (("NTSTATUS: %s", nt_errstr(status)));
+
   return -1;
 }


### PR DESCRIPTION
Also, wmi_query and wmi_query_rsop return the error code for other errors than "INVALID_CLASS".
Fix docstrings.