### PR TITLE
Omit timestamp from PE executable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 ### Changed
+- Build winexesvc without timestamps to make binaries reproducible [#40](https://github.com/greenbone/openvas-smb/pull/40)
 ### Fixed
 ### Removed
 

--- a/winexe/CMakeLists.txt
+++ b/winexe/CMakeLists.txt
@@ -71,7 +71,7 @@ set (BINTOC_SOURCES
 
 add_custom_command(
    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/winexesvc.exe
-   COMMAND ${MINGW_GCC} ${WINEXESVC_SOURCES} -o winexesvc.exe
+   COMMAND ${MINGW_GCC} -Xlinker --no-insert-timestamp ${WINEXESVC_SOURCES} -o winexesvc.exe
    DEPENDS ${WINEXESVC_SOURCES})
 
 add_custom_command(

--- a/winexe/changes
+++ b/winexe/changes
@@ -1,3 +1,4 @@
+0.81 - 2021-06-12 build with --no-insert-timestamp to make binaries reproducible.
 0.80 - 26/10/07 Added --interactive option.
     winexesvc is replaced only if version differs on more than last digit.
 0.77 - 11/10/07 Fixed bug causing winexe crash during service uninstallation.

--- a/winexe/config.mk
+++ b/winexe/config.mk
@@ -17,7 +17,7 @@ PRIVATE_DEPENDENCIES = \
 #################################
 # Start Library libwincmd
 [LIBRARY::wincmd]
-VERSION=0.80
+VERSION=0.81
 SO_VERSION=1
 LIBRARY_REALNAME = libwincmd.$(SHLIBEXT)
 OBJ_FILES = \


### PR DESCRIPTION
Omit timestamp from PE executable
to make binaries reproducible.
See https://reproducible-builds.org/ for why this is good.

This PR was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).