### PR TITLE
Update DCOM Version

### DIFF
--- a/samba/librpc/idl/orpc.idl
+++ b/samba/librpc/idl/orpc.idl
@@ -30,7 +30,7 @@ interface ObjectRpcBaseTypes
 
 	/* current version */
 	const uint16 COM_MAJOR_VERSION = 5;
-	const uint16 COM_MINOR_VERSION = 1;
+	const uint16 COM_MINOR_VERSION = 7;
 
 	/* Body Extensions */
 	const string dcom_ext_debugging = "f1f19680-4d2a-11ce-a66a-0020af6e72f4";


### PR DESCRIPTION
Change COM_MINOR_VERSION from 1 to 7 in samba/librpc/idl/orpc.idl to fix WMI client not working with Windows Server 2022.

5.7 is supported down to including Windows XP as per https://docs.microsoft.com/en-us/answers/questions/146551/wmic-stopped-working-on-windows-10-2004.html somewhere down in the comments of a Microsoft employee.

Fixes #45