### PR TITLE
release workflow

### DIFF
--- a/.docker/build.Dockerfile
+++ b/.docker/build.Dockerfile
@@ -1,14 +1,14 @@
 FROM debian:stable-slim
-
+LABEL deprecated="This image is deprecated and may be removed soon."
 RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y \
-    build-essential \
-    cmake \
-    pkg-config \
-    gcc-mingw-w64 \
-    libgnutls28-dev \
-    perl-base \
-    heimdal-dev \
-    libpopt-dev \
-    libglib2.0-dev \
-    libunistring-dev \
-    && rm -rf /var/lib/apt/lists/*
+  build-essential \
+  cmake \
+  pkg-config \
+  gcc-mingw-w64 \
+  libgnutls28-dev \
+  perl-base \
+  heimdal-dev \
+  libpopt-dev \
+  libglib2.0-dev \
+  libunistring-dev \
+  && rm -rf /var/lib/apt/lists/*

--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -1,8 +1,8 @@
 ARG VERSION=latest
 
-FROM greenbone/openvas-smb-build:$VERSION AS build
-
+FROM debian:stable-slim AS build
 COPY . /source
+RUN sh /source/install-openvas-smb-dependencies.sh
 
 RUN cmake -DCMAKE_BUILD_TYPE=Release -B/build /source
 RUN DESTDIR=/install cmake --build /build -- install
@@ -10,14 +10,14 @@ RUN DESTDIR=/install cmake --build /build -- install
 FROM debian:stable-slim
 
 RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y \
-    libgnutls30 \
-    libgssapi3-heimdal \
-    libkrb5-26-heimdal \
-    libasn1-8-heimdal \
-    libroken18-heimdal \
-    libhdb9-heimdal \
-    libpopt0 \
-    && rm -rf /var/lib/apt/lists/*
+  libgnutls30 \
+  libgssapi3-heimdal \
+  libkrb5-26-heimdal \
+  libasn1-8-heimdal \
+  libroken18-heimdal \
+  libhdb9-heimdal \
+  libpopt0 \
+  && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /install/ /
 

--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -2,7 +2,7 @@ ARG VERSION=latest
 
 FROM debian:stable-slim AS build
 COPY . /source
-RUN sh /source/install-openvas-smb-dependencies.sh
+RUN sh /source/.github/install-openvas-smb-dependencies.sh
 
 RUN cmake -DCMAKE_BUILD_TYPE=Release -B/build /source
 RUN DESTDIR=/install cmake --build /build -- install

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
 .docker
-.github
 changelog
 build

--- a/.github/enhance_version.sh
+++ b/.github/enhance_version.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+version="$1"
+type="$2"
+
+# Split version string into fields
+IFS='.' read -r field1 field2 field3 << EOF
+$version
+EOF
+
+# On major enhance major version, set minor and patch to 0
+# On minor enhance minor version, set patch to 0
+# On patch enhance patch version
+case "$type" in
+  "major")
+    field1=$(expr $field1 + 1)
+    field2=0
+    field3=0
+    ;;
+  "minor")
+    field2=$(expr $field2 + 1)
+    field3=0
+    ;;
+  "patch")
+    field3=$(expr $field3 + 1)
+    ;;
+  *)
+    echo "Error: Invalid update type '$type'" >&2
+    return 1
+    ;;
+esac
+
+new_version="$field1.$field2.$field3"
+echo "$new_version"

--- a/.github/install-openvas-smb-dependencies.sh
+++ b/.github/install-openvas-smb-dependencies.sh
@@ -1,0 +1,15 @@
+# This script installs openvas-smb-dependencies.
+#/bin/sh
+set -ex
+apt-get update && apt-get install --no-install-recommends --no-install-suggests -y \
+    build-essential \
+    cmake \
+    pkg-config \
+    gcc-mingw-w64 \
+    libgnutls28-dev \
+    perl-base \
+    heimdal-dev \
+    libpopt-dev \
+    libglib2.0-dev \
+    libunistring-dev \
+    && rm -rf /var/lib/apt/lists/*

--- a/.github/sign-assets.sh
+++ b/.github/sign-assets.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -e
+
+# use own gpg_home to not intefere with other settings
+tmp=
+trap 'rm -rf "$tmp"' EXIT INT TERM HUP
+tmp=$(mktemp -d)
+export GNUPGHOME="$tmp"
+# enable gpg to work in container environments:
+# https://d.sb/2016/11/gpg-inappropriate-ioctl-for-device-errors
+printf "use-agent\npinentry-mode loopback" > $GNUPGHOME/gpg.conf
+printf "allow-loopback-pinentry" > $GNUPGHOME/gpg-agent.conf
+echo RELOADAGENT | gpg-connect-agent
+# store password, we need it multiple times
+read -s password
+# store to file
+mv "$1" "$GNUPGHOME/private.pgp"
+# import and gather key id
+key_id=$(echo "$password" | \
+  gpg --import --batch --armor --passphrase-fd 0 $GNUPGHOME/private.pgp 2>&1 | \
+  grep "key [A-Z0-9]*:" | \
+  head -n 1 | \
+  sed 's/.*key \([A-Z0-9]*\):.*/\1/')
+  echo "key_id: $key_id"
+
+# Create a signed ASC for each file in the assets directory
+for file in assets/*; do
+  if [ -f "$file" ]; then
+    echo $password | gpg --default-key $key_id --batch --passphrase-fd 0 --clear-sign --detach-sign "$file"
+  fi
+done
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,161 @@
+name: "release"
+
+on:
+  pull_request:
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      release:
+        description: "Use 'major' for incompatible changes, 'minor' for new features, and 'patch' for fixes."
+        type: choice
+        options:
+          - "major"
+          - "minor"
+          - "patch"
+        required: true
+        default: "patch"
+
+
+# This job first determines the target branch of the closed pull request. If the target branch is "main",
+# then the latest release tag is used. If no release tag exists, it is set to 0.1.0. If it is a release
+# branch (e.g. v22), then the latest tag within that major version is used.
+#
+# For a patch release, the latest tag is enhanced with 0.0.1, leaving the major and minor versions as
+# they are.
+#
+# For a minor release, the latest tag is enhanced with 0.1.0, and the patch version is set to 0. 
+#
+# For a major release, a branch is created for the latest major release found by tag, and the version
+# is enhanced with $latest_tag + 1.0.0, increasing the major version by 1 and setting the minor and
+# patch versions to 0.
+#
+# Major version releases are only valid on the "main" branch.
+# 
+# Once the version is found and enhanced, each CMakeLists file is updated to the new
+# version, and a commit is created in the found branch.
+jobs:
+  release:
+    name: release
+    if: |
+      ${{
+        (github.event_name == 'workflow_dispatch') ||
+        (
+          ( github.event.pull_request.merged == true) &&
+          ( 
+            contains(github.event.pull_request.labels.*.name, 'major_release') ||
+            contains(github.event.pull_request.labels.*.name, 'minor_release') ||
+            contains(github.event.pull_request.labels.*.name, 'patch_release')
+          )
+        )
+      }}
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: set RELEASE_KIND = ${{ github.event.inputs.release }}
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          echo "RELEASE_KIND=${{ github.event.inputs.release }}" >> $GITHUB_ENV
+      - name: set RELEASE_KIND = major
+        if: ${{ (contains(github.event.pull_request.labels.*.name, 'major_release')) }}
+        run: |
+          echo "RELEASE_KIND=major" >> $GITHUB_ENV
+      - name: set RELEASE_KIND = minor
+        if: ${{ (contains(github.event.pull_request.labels.*.name, 'minor_release')) }}
+        run: |
+          echo "RELEASE_KIND=minor" >> $GITHUB_ENV
+      - name: set RELEASE_KIND = patch
+        if: ${{ (contains(github.event.pull_request.labels.*.name, 'patch_release')) }}
+        run: |
+          echo "RELEASE_KIND=patch" >> $GITHUB_ENV
+      - name: set RELEASE_REF
+        run: |
+          if [[ "${{ github.event_name }}" = "workflow_dispatch" ]]; then
+            echo "RELEASE_REF=${{ github.ref_name }}" >> $GITHUB_ENV
+          else
+            echo "RELEASE_REF=${{ github.base_ref }}" >> $GITHUB_ENV
+          fi
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GREENBONE_BOT_TOKEN }}
+          fetch-depth: '0'
+      - name: "LATEST_VERSION"
+        run: |
+          if [[ "${{ env.RELEASE_REF }}" = "main" ]]; then
+            echo "LATEST_VERSION=$(git tag | grep "^v" | sed 's/^v//' | sort --version-sort | tail -n 1)" >> $GITHUB_ENV
+          else
+            echo "LATEST_VERSION=$(git tag | grep "^v${{ env.RELEASE_REF }}" | sed 's/^v//' | sort --version-sort | tail -n 1)" >> $GITHUB_ENV
+          fi
+      - name: "default LATEST_VERSION"
+        run: |
+          # default to 0.1.0 when there is no previous tag and on main branch
+          if ([[ -z "${{ env.LATEST_VERSION }}" ]] &&  [[ "${{ env.RELEASE_REF }}" = "main" ]]); then
+            echo "LATEST_VERSION=0.1.0" >> $GITHUB_ENV
+          fi
+      # safeguard
+      - name: RELEASE_REF != NULL
+        run: ([ -n "${{ env.RELEASE_REF }}" ])
+      - name: LATEST_VERSION != NULL
+        run: ([ -n "${{ env.LATEST_VERSION }}" ])
+      - name: RELEASE_KIND != NULL
+        run: ([ -n "${{ env.RELEASE_KIND }}" ])
+      - name: "NEW_VERSION"
+        run: |
+          echo "NEW_VERSION=$(sh .github/enhance_version.sh ${{ env.LATEST_VERSION }} ${{ env.RELEASE_KIND }})" >> $GITHUB_ENV
+      - name: NEW_VERSION != NULL
+        run: ([ -n "${{ env.NEW_VERSION }}" ])
+      - name: set git credentials
+        run: |
+             git config --global user.email "${{ secrets.GREENBONE_BOT_MAIL }}"
+             git config --global user.name "${{ secrets.GREENBONE_BOT }}"
+      - name: "create working branch for previous major release (${{ env.LATEST_VERSION }})"
+        if: ( env.RELEASE_KIND == 'major' )
+        run: |
+          # save a branch so that we can easily create PR for that version when we want to fix something
+          git checkout "v${{ env.LATEST_VERSION }}"
+          export BRANCH_NAME=$(echo "${{ env.LATEST_VERSION }}" | sed 's/^\([0-9]*\).*/v\1/')
+          git checkout -b "$BRANCH_NAME"
+          git push origin "$BRANCH_NAME"
+      # create branch of version 
+      - name: prepare project version ${{ env.RELEASE_REF }} ${{ env.LATEST_VERSION }} -> ${{ env.NEW_VERSION }}
+        run: |
+          # jump back for the case that we switched to a tag
+          git checkout "${{ env.RELEASE_REF }}"
+          # change version
+          sed -i.bak 's/^\([ ]*\)VERSION [0-9]*.[0-9]*.[0-9]*/\1VERSION ${{ env.NEW_VERSION }}/' CMakeLists.txt
+          # disable PROJECT_DEV_VERSION for tag
+          sed -i.bak 's/set (PROJECT_DEV_VERSION 1)/set (PROJECT_DEV_VERSION 0)/' CMakeLists.txt
+          if git diff --exit-code --quiet; then
+            echo "There are no modified files, skipping."
+          else
+            git add CMakeLists.txt
+            git commit -m "Automated commit: change version from ${{ env.LATEST_VERSION }} -> ${{ env.NEW_VERSION }}"
+            git push origin ${{ env.RELEASE_REF }}
+          fi
+
+      - run: mkdir assets/
+      - name: release ${{ env.LATEST_VERSION }} -> ${{ env.NEW_VERSION }}
+        run: |
+          python3 -m pip install pontos
+          pontos-changelog \
+            --current-version ${{ env.LATEST_VERSION }} \
+            --next-version ${{ env.NEW_VERSION }} \
+            --config changelog.toml \
+            --project openvas-scanner \
+            --versioning-scheme semver \
+            -o /tmp/changelog.md   || true
+          # we would rather have empty release notes than no release
+          if [ ! -f "/tmp/changelog.md" ]; then
+            touch /tmp/changelog.md
+          fi
+          echo "${{ secrets.GREENBONE_BOT_TOKEN }}" | gh auth login --with-token
+          # lets see how smart it is
+          export nrn="v${{ env.NEW_VERSION }}"
+          gh release create "$nrn" -F /tmp/changelog.md
+          mkdir -p assets
+          ls -las assets/
+          curl -Lo assets/$nrn.zip https://github.com/nichtsfrei/openvas-scanner/archive/refs/tags/$nrn.zip
+          curl -Lo assets/$nrn.tar.gz https://github.com/nichtsfrei/openvas-scanner/archive/refs/tags/$nrn.tar.gz
+          echo -e "${{ secrets.GPG_KEY }}" > private.pgp
+          echo ${{ secrets.GPG_PASSPHRASE }} | bash .github/sign-assets.sh private.pgp
+          rm assets/$nrn.zip
+          rm assets/$nrn.tar.gz
+          gh release upload $nrn assets/*

--- a/changelog.toml
+++ b/changelog.toml
@@ -1,0 +1,8 @@
+commit_types = [
+    { message = "^add", group = "Added"},
+    { message = "^remove", group = "Removed"},
+    { message = "^change", group = "Changed"},
+    { message = "^fix", group = "Bug Fixes"},
+]
+
+changelog_dir = "changelog"


### PR DESCRIPTION
# CI: Implement a new release

The new release process includes the following changes:

1. We now base releases on git tags instead of individual projects.
1. We use major, minor, and patch releases instead of just patch releases.
1. Releases are made from the main branch instead of stable or unstable branches.
1. For major releases, we create a version branch to handle hotfixes.
1. Each project within the repository has the same version.

To initiate the release process, you can either add one of the following labels
to a pull request:
- `major_release`,
- `minor_release`,
- `patch_release`.

Once the PR is merged, the release process will be triggered.

Alternatively, you can initiate the release via the GitHub action page.

Note that we are currently working on creating a docker image for releases,
which will require new docker tag layout and compose changes.

# Switches from build-image to gvm-libs and install dependencies.

Enhances the robustness of the CI process by using GVM-libs and
installing the required dependencies, instead of relying on a pre-built
image that must be pushed before running CI tests.
This approach eliminates the need to push dependencies beforehand and
wait for a docker image to be pushed before utilizing it.
