### PR TITLE
Adapt docker images

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,21 +1,46 @@
-name: Container
+name: Container Image Builds
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     tags: ["v*"]
   pull_request:
-    branches: [ main ]
+    branches: [main]
   workflow_dispatch:
 
 jobs:
-  main:
-    name: Upload production image
+  production:
+    name: Production Images
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@v3
-      - name: Setup container meta information
+      - name: 'set IS_VERSION_TAG'
+        run: |
+          echo "IS_VERSION_TAG=${{ github.ref_type == 'tag' && startsWith(github.ref_name, 'v') }}" >> $GITHUB_ENV
+          # set defaults
+          echo "IS_LATEST_TAG=false" >> $GITHUB_ENV
+      - name: 'set IS_LATEST_TAG'
+        if: ( env.IS_VERSION_TAG )
+        run: |
+          # find the latest version that is not ourself
+          export LATEST_VERSION=$(git tag -l | grep -v '${{ github.ref_name }}' | sort -r --version-sort)
+          # get major minor patch versions
+          IFS='.' read -r latest_major latest_minor latest_patch << EOF
+          $LATEST_VERSION
+          EOF
+          IFS='.' read -r tag_major tag_minor tag_patch << EOF
+          ${{ github.ref_name }}
+          EOF
+          # remove leading v
+          latest_major=$(echo $latest_major | cut -c2-)
+          tag_major=$(echo $tag_major | cut -c2-)
+          echo "$tag_major >= $latest_major"
+          if [[ $tag_major -ge $latest_major && ($tag_minor -ne 0 || $tag_patch -ne 0) ]]; then
+            # set this tag to latest and stable
+            echo "IS_LATEST_TAG=true" >> $GITHUB_ENV
+          fi
+      - name: 'Setup meta information (IS_VERSION_TAG: ${{ env.IS_VERSION_TAG }}, IS_LATEST_TAG: ${{ env.IS_LATEST_TAG }} )'
         id: meta
         uses: docker/metadata-action@v4
         with:
@@ -23,28 +48,36 @@ jobs:
           labels: |
             org.opencontainers.image.vendor=Greenbone
             org.opencontainers.image.base.name=debian:stable-slim
-          flavor: latest=false # no latest container tag for git tags
+          flavor: latest=false # no auto latest container tag for git tags
           tags: |
-            # create container tag for git tags
-            type=ref,event=tag
+            # when IS_LATEST_TAG is set create a stable and a latest tag
+            type=raw,value=latest,enable=${{ env.IS_LATEST_TAG }}
+            type=raw,value=stable,enable=${{ env.IS_LATEST_TAG }}
+            # if tag version is set than create a version tags
+            type=semver,pattern={{version}},enable=${{ env.IS_VERSION_TAG }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ env.IS_VERSION_TAG }}
+            type=semver,pattern={{major}},enable=${{ env.IS_VERSION_TAG }}
+            # if we are on the main branch set edge
+            type=edge,branch=main
+            # use branch-sha otherwise for pushes to branches other then main (will not be uploaded)
+            type=raw,value={{branch}}-{{sha}},enable=${{ github.ref_type == 'branch' && github.event_name == 'push' && github.ref_name != 'main' }}
+            # use pr-$PR_ID for pull requests (will not be uploaded)
             type=ref,event=pr
-            # use latest for main branch
-            type=raw,value=latest,enable={{is_default_branch}}
-      - name: Login to DockerHub
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Registry
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Build and push
+      - name: Build and push Container image
         uses: docker/build-push-action@v4
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request' && (github.ref_type == 'tag' || github.ref_name == 'main') }}
           file: .docker/prod.Dockerfile
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
Pushes the version tags to docker hub on a tag release

- greenbone/openvas-smb:${major}
- greenbone/openvas-smb:${major.minor}
- greenbone/openvas-smb:${major.minor.patch}

This will allow container users to choose the newest 22 without having to adapt to each minor or patch version manually. If the latest 22 is buggy, they can jump back to either a patch or a minor version until there is a new 22 version that fixes it.

When the tag version is the highest major version and is not the first major release with minor and patch version is 0 than it also creates a latest and stable tag.

Just to give an overview, here are some examples:

Release 22.5.1 on greenbone/openvas-smb would result in the following tags:

- greenbone/openvas-smb:22
- greenbone/openvas-smb:22.5
- greenbone/openvas-smb:22.5.1
- greenbone/openvas-smb:latest
- greenbone/openvas-smb:stable

Release 23.0.0 on greenbone/openvas-smb would result in the following tags:

- greenbone/openvas-smb:23
- greenbone/openvas-smb:23.0
- greenbone/openvas-smb:23.0.0

Release 23.0.1 on greenbone/openvas-smb would result in the following tags:

- greenbone/openvas-smb:23
- greenbone/openvas-smb:23.0
- greenbone/openvas-smb:23.0.1
- greenbone/openvas-smb:latest
- greenbone/openvas-smb:stable

Release 22.5.2 when there is already a 23.0.1 version available would result in the following tags:

- greenbone/openvas-smb:22
- greenbone/openvas-smb:22.5
- greenbone/openvas-smb:22.5.2