### PR TITLE
Fix: issue related to a fix in popt v1.19

### DIFF
--- a/wmi/CMakeLists.txt
+++ b/wmi/CMakeLists.txt
@@ -37,6 +37,7 @@ set (SMB_INCLUDES
 include_directories(${SMB_INCLUDES} ${CMAKE_CURRENT_SOURCE_DIR}/..)
 
 set(WMI_SHARED_SRC
+   program_args_utils.c
    wmicore.c
    wbemdata.c
 )

--- a/wmi/program_args_utils.c
+++ b/wmi/program_args_utils.c
@@ -1,0 +1,37 @@
+/* SPDX-FileCopyrightText: 2023 Greenbone AG
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+#include <stdlib.h>
+#include "program_args_utils.h"
+
+void free_program_args(progr_args_t *pa) {
+
+  if (pa == NULL)
+    return;
+  
+  if (pa->hostname){
+    free(pa->hostname);
+    pa->hostname = NULL;
+  }
+  if (pa->query) {
+    free(pa->query);
+    pa->query = NULL;
+  }
+  if (pa->delim){
+    free(pa->delim);
+    pa->delim = NULL;
+  }
+  if (pa->ns){
+    free(pa->ns);
+    pa->ns = NULL;
+  }
+  free(pa);
+  pa = NULL;
+}
+
+progr_args_t *
+init_program_args () {
+  progr_args_t *args = calloc(1, sizeof(progr_args_t));
+  return args;
+}

--- a/wmi/program_args_utils.h
+++ b/wmi/program_args_utils.h
@@ -1,0 +1,21 @@
+/* SPDX-FileCopyrightText: 2023 Greenbone AG
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#ifndef WMI_ARGS_H_
+#define WMI_ARGS_H_
+
+struct program_args {
+    char *hostname;
+    char *query;
+    char *delim;
+    char *ns;
+
+};
+typedef struct program_args progr_args_t;
+
+void free_program_args(progr_args_t *);
+progr_args_t *init_program_args();
+
+#endif // finish WMI_ARGS_H_


### PR DESCRIPTION
## What

With the new popt release, a memory leak was fixed. Wmic relais into the leak to get the command line options (hostname, namespace, etc). Once the leak is fixed, the command line options are not available anymore.

This patch makes a deep copy of the options and now are available again.

Also, adds a new file with structure definition and functions to init and free the structure with the program arguments, necessary not only for wmic, but also for other libs related to wmi (wmireg, wmirsop).

Close #77 
Close https://github.com/greenbone/openvas-scanner/issues/1491

Jira: SC-923
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
wmi didn't work. This patch solve it.
<!-- Describe why are these changes necessary? -->

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


