### PR TITLE
Change: Revert #83

### DIFF
--- a/samba/lib/com/dcom/main.c
+++ b/samba/lib/com/dcom/main.c
@@ -511,7 +511,7 @@ static struct composite_context *dcom_determine_rpc_binding(
     if (!NT_STATUS_IS_OK(status))
     {
         /* build a binding string using NCACN_IP_TCP */
-        char *bindstr = talloc_asprintf(c, "ncacn_ip_tcp:%s[sign,seal]", server);
+        char *bindstr = talloc_asprintf(c, "ncacn_ip_tcp:%s", server);
         if (composite_nomem(bindstr, c)) return c;
 
         status = dcerpc_parse_binding(c, bindstr, &activation_state->binding);


### PR DESCRIPTION
## What
Revert #83, which added connection options in a hardcoded way.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
With greenbone/openvas-scanner#1355 this options can be added when calling wmic or wmi via the library, and  currently defaults to [sign]. This hardcoded options collide with the default or provided one. 

<!-- Describe why are these changes necessary? -->

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


