### PR TITLE
Fix: docker container use heimdal-multidev

### DIFF
--- a/.github/install-openvas-smb-dependencies.sh
+++ b/.github/install-openvas-smb-dependencies.sh
@@ -8,7 +8,7 @@ apt-get update && apt-get install --no-install-recommends --no-install-suggests 
     gcc-mingw-w64 \
     libgnutls28-dev \
     perl-base \
-    heimdal-dev \
+    heimdal-multidev \
     libpopt-dev \
     libglib2.0-dev \
     libunistring-dev \

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,7 +11,7 @@ Prerequisites for openvas-smb
 * gcc-mingw32 | gcc-mingw-w64
 * libgnutls-dev >= 3.2.15
 * perl-base
-* heimdal-dev | heimdal-multidev >= 1.6.0
+* heimdal-multidev >= 1.6.0
 * libpopt-dev
 * libglib2.0-dev
 * libunistring-dev


### PR DESCRIPTION
Because openvas-scanner has a dependency to mitkrb5
openvas-smb must use heimdal-multidev so it can be
installed together on debian systems.

To reflect that the INSTALL.md and Dockerfile are adjusted.

https://github.com/greenbone/openvas-scanner/issues/1803
