### PR TITLE
Fix: solve issue when using cmake>4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 
 project(openvas-smb
   VERSION 22.5.7


### PR DESCRIPTION

## What
  solve issue when using cmake>4.0
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
Cmake v4.0 or later don't work anymore with deprecated stuff from cmake version < 3.5. Also, it triggers a warning if the minimum version is set to somethink <3.10.

Therefore, setting the minimum required version to 3.10.

I have tested with version 4.0.1 and cmake works as expected, so nothing else to be changed beside the version. Also, we need to support at least cmake 3.18, the one in Debian Bullseye, one of our supported base systems.

<!-- Describe why are these changes necessary? -->

## References
  Closes #94 
  Jira: SC-1296

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


