### PR TITLE
Fix: add cflags to treat errors as warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,7 +154,8 @@ if(${GSSAPI_VERSION} VERSION_LESS "7.5.0")
 	add_definitions(-DOLD_HEIMDAL)
 endif()
 set (CMAKE_C_FLAGS "-fPIC -O2 -D_FORTIFY_SOURCE=2 -fstack-protector ${CMAKE_C_FLAGS}")
-set (CMAKE_C_FLAGS "-Wno-unused-result -fno-strict-aliasing ${CMAKE_C_FLAGS}")
+set (CMAKE_C_FLAGS "-Wno-incompatible-pointer-types -Wno-implicit-function-declaration -Wno-unused-result -fno-strict-aliasing ${CMAKE_C_FLAGS}")
+
 set (LINKER_HARDENING_FLAGS     "-Wl,-z,relro -Wl,-z,now")
 
 ## Version


### PR DESCRIPTION
## What
treat errors as warnings.
Jira: SC-1336
Close #96 

Related to  #90
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
Known issues are treated as errors by gcc-14 . With this patch the errros are treated as warnings and openvas-smb compiles as before.
<!-- Describe why are these changes necessary? -->

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


