### PR TITLE
Change: Migrate release changelog generation from Pontos to git-cliff

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,44 +37,46 @@ jobs:
   release:
     name: release
     if: |
-        (github.event_name == 'workflow_dispatch') ||
+      (github.event_name == 'workflow_dispatch') ||
+      (
+        github.event.pull_request.merged == true &&
         (
-          github.event.pull_request.merged == true &&
-          ( 
-            contains(github.event.pull_request.labels.*.name, 'major_release') ||
-            contains(github.event.pull_request.labels.*.name, 'minor_release') ||
-            contains(github.event.pull_request.labels.*.name, 'patch_release')
-          )
+          contains(github.event.pull_request.labels.*.name, 'major_release') ||
+          contains(github.event.pull_request.labels.*.name, 'minor_release') ||
+          contains(github.event.pull_request.labels.*.name, 'patch_release')
         )
-    runs-on: "ubuntu-latest"
+      )
+    runs-on: ubuntu-latest
     steps:
-      - name: set RELEASE_KIND = ${{ github.event.inputs.release }}
+      - name: Set RELEASE_KIND = ${{ github.event.inputs.release }}
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: |
-          echo "RELEASE_KIND=${{ github.event.inputs.release }}" >> $GITHUB_ENV
-      - name: set RELEASE_KIND = major
-        if: ${{ (contains(github.event.pull_request.labels.*.name, 'major_release')) }}
-        run: |
-          echo "RELEASE_KIND=major" >> $GITHUB_ENV
-      - name: set RELEASE_KIND = minor
-        if: ${{ (contains(github.event.pull_request.labels.*.name, 'minor_release')) }}
-        run: |
-          echo "RELEASE_KIND=minor" >> $GITHUB_ENV
-      - name: set RELEASE_KIND = patch
-        if: ${{ (contains(github.event.pull_request.labels.*.name, 'patch_release')) }}
-        run: |
-          echo "RELEASE_KIND=patch" >> $GITHUB_ENV
-      - name: set RELEASE_REF
+        run: echo "RELEASE_KIND=${{ github.event.inputs.release }}" >> $GITHUB_ENV
+
+      - name: Set RELEASE_KIND = major
+        if: ${{ contains(github.event.pull_request.labels.*.name, 'major_release') }}
+        run: echo "RELEASE_KIND=major" >> $GITHUB_ENV
+
+      - name: Set RELEASE_KIND = minor
+        if: ${{ contains(github.event.pull_request.labels.*.name, 'minor_release') }}
+        run: echo "RELEASE_KIND=minor" >> $GITHUB_ENV
+
+      - name: Set RELEASE_KIND = patch
+        if: ${{ contains(github.event.pull_request.labels.*.name, 'patch_release') }}
+        run: echo "RELEASE_KIND=patch" >> $GITHUB_ENV
+
+      - name: Set RELEASE_REF
         run: |
           if [[ "${{ github.event_name }}" = "workflow_dispatch" ]]; then
             echo "RELEASE_REF=${{ github.ref_name }}" >> $GITHUB_ENV
           else
             echo "RELEASE_REF=${{ github.base_ref }}" >> $GITHUB_ENV
           fi
+
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GREENBONE_BOT_TOKEN }}
           fetch-depth: '0'
+
       - name: "LATEST_VERSION"
         run: |
           if [[ "${{ env.RELEASE_REF }}" = "main" ]]; then
@@ -82,12 +84,14 @@ jobs:
           else
             echo "LATEST_VERSION=$(git tag | grep "^v${{ env.RELEASE_REF }}" | sed 's/^v//' | sort --version-sort | tail -n 1)" >> $GITHUB_ENV
           fi
+
       - name: "default LATEST_VERSION"
         run: |
           # default to 0.1.0 when there is no previous tag and on main branch
           if ([[ -z "${{ env.LATEST_VERSION }}" ]] &&  [[ "${{ env.RELEASE_REF }}" = "main" ]]); then
             echo "LATEST_VERSION=0.1.0" >> $GITHUB_ENV
           fi
+
       # safeguard
       - name: RELEASE_REF != NULL
         run: ([ -n "${{ env.RELEASE_REF }}" ])
@@ -112,6 +116,7 @@ jobs:
           export BRANCH_NAME=$(echo "${{ env.LATEST_VERSION }}" | sed 's/^\([0-9]*\).*/v\1/')
           git checkout -b "$BRANCH_NAME"
           git push origin "$BRANCH_NAME"
+
       # create branch of version 
       - name: prepare project version ${{ env.RELEASE_REF }} ${{ env.LATEST_VERSION }} -> ${{ env.NEW_VERSION }}
         run: |
@@ -128,28 +133,26 @@ jobs:
             git push origin ${{ env.RELEASE_REF }}
           fi
 
-      - run: mkdir assets/
-      - name: release ${{ env.LATEST_VERSION }} -> ${{ env.NEW_VERSION }}
+      - run: mkdir -p assets/
+
+      # changelog and release block (updated for git-cliff)
+      - name: Install git-cliff
+        uses: greenbone/actions/uv@v3
+        with:
+          install: git-cliff
+
+      - name: Generate changelog with git-cliff
+        run: |
+          git-cliff -v --strip header -o /tmp/changelog.md --tag "${{ env.NEW_VERSION }}" "v${{ env.LATEST_VERSION }}..HEAD"
+
+      - name: Create GitHub Release & Upload Assets
+        env:
+          GH_TOKEN: ${{ secrets.GREENBONE_BOT_TOKEN }}
         run: |
           export PROJECT=$(echo "${{ github.repository }}" | sed 's/.*\///' )
-          pontos-changelog \
-            --current-version ${{ env.LATEST_VERSION }} \
-            --next-version ${{ env.NEW_VERSION }} \
-            --config changelog.toml \
-            --project $PROJECT \
-            --versioning-scheme semver \
-            -o /tmp/changelog.md   || true
-          # we would rather have empty release notes than no release
-          if [ ! -f "/tmp/changelog.md" ]; then
-            touch /tmp/changelog.md
-          fi
-          echo "${{ secrets.GREENBONE_BOT_TOKEN }}" | gh auth login --with-token
-          # lets see how smart it is
           export nrn="v${{ env.NEW_VERSION }}"
           export filename="$PROJECT-$nrn"
           gh release create "$nrn" -F /tmp/changelog.md
-          mkdir -p assets
-          ls -las assets/
           curl -Lo assets/$filename.zip https://github.com/${{ github.repository }}/archive/refs/tags/$nrn.zip
           curl -Lo assets/$filename.tar.gz https://github.com/${{ github.repository }}/archive/refs/tags/$nrn.tar.gz
           echo -e "${{ secrets.GPG_KEY }}" > private.pgp

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,7 +143,11 @@ jobs:
 
       - name: Generate changelog with git-cliff
         run: |
-          git-cliff -v --strip header -o /tmp/changelog.md --tag "${{ env.NEW_VERSION }}" "v${{ env.LATEST_VERSION }}..HEAD"
+          git-cliff -v --strip header -o /tmp/changelog.md --config cliff.toml --tag "${{ env.NEW_VERSION }}" "v${{ env.LATEST_VERSION }}..HEAD"
+          # Fallback if changelog is empty
+          if [ ! -s "/tmp/changelog.md" ]; then
+            echo "No release notes. See commit history for details." > /tmp/changelog.md
+          fi
 
       - name: Create GitHub Release & Upload Assets
         env:

--- a/README.md
+++ b/README.md
@@ -16,16 +16,24 @@ binary to execute queries remotely on that system.
 
 This module can be configured, built and installed with following commands:
 
-    cmake .
-    make install
+```sh
+cmake .
+make install
+```
 
-For detailed installation requirements and instructions, please see the file
-[INSTALL.md](INSTALL.md).
+For detailed installation requirements and instructions, please see [INSTALL.md](INSTALL.md).
 
 If you are not familiar or comfortable building from source code, we recommend
-that you use the Greenbone Enterprise TRIAL, a prepared virtual machine with a
+using the Greenbone Enterprise TRIAL, a prepared virtual machine with a
 readily available setup. Information regarding the virtual machine
 is available at <https://www.greenbone.net/en/testnow>.
+
+## Releases & Changelog
+
+All releases are published on [GitHub Releases](https://github.com/greenbone/openvas-smb/releases).  
+Changelogs are automatically generated using [git-cliff](https://github.com/orhun/git-cliff) and are included with each release for transparency and consistency.
+
+For details about our changelog style or to contribute meaningful commit messages, see the [cliff.toml](cliff.toml) configuration.
 
 ## Support
 
@@ -43,8 +51,10 @@ This project is maintained by [Greenbone AG](https://www.greenbone.net/).
 
 Your contributions are highly appreciated. Please [create a pull
 request](https://github.com/greenbone/openvas-smb/pulls) on GitHub. Bigger
-changes need to be discussed with the development team via the [issues section
-at github](https://github.com/greenbone/openvas-smb/issues) first.
+changes should be discussed with the development team via the [issues section
+at GitHub](https://github.com/greenbone/openvas-smb/issues) first.
+
+When contributing, please follow our commit message guidelines for changelog clarity (see [cliff.toml](cliff.toml)).
 
 ## License
 

--- a/changelog.toml
+++ b/changelog.toml
@@ -1,8 +1,0 @@
-commit_types = [
-    { message = "^add", group = "Added"},
-    { message = "^remove", group = "Removed"},
-    { message = "^change", group = "Changed"},
-    { message = "^fix", group = "Bug Fixes"},
-]
-
-changelog_dir = "changelog"

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,87 @@
+[changelog]
+# template for the changelog header
+header = """
+# Changelog\n
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).\n
+"""
+# template for the changelog body
+# https://keats.github.io/tera/docs/#introduction
+body = """
+{%- macro remote_url() -%}
+  https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}
+{%- endmacro -%}
+
+{% if version -%}
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else -%}
+    ## [Unreleased]
+{% endif -%}
+
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | upper_first }}
+    {% for commit in commits %}
+        - {{ commit.message | split(pat="\n") | first | upper_first | trim }}\
+            {% if commit.remote.username %} by [@{{ commit.remote.username }}](https://github.com/{{ commit.remote.username }}){%- endif -%}
+            {% if commit.remote.pr_number %} in \
+            [#{{ commit.remote.pr_number }}]({{ self::remote_url() }}/pull/{{ commit.remote.pr_number }}) \
+            {% elif commit.id %} in \
+            [{{ commit.id | truncate(length=7, end="") }}]({{ self::remote_url() }}/commit/{{ commit.id }})\
+            {%- endif -%}
+    {% endfor %}
+{% endfor -%}
+"""
+# template for the changelog footer
+footer = """
+{%- macro remote_url() -%}
+  https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}
+{%- endmacro -%}
+
+{% for release in releases %}
+    {% if release.version -%}
+        {% if release.previous.version -%}
+            [{{ release.version | trim_start_matches(pat="v") }}]: \
+                {{ self::remote_url() }}/compare/{{ release.previous.version }}..{{ release.version }}
+        {% endif -%}
+    {% else -%}
+        [unreleased]: {{ self::remote_url() }}/compare/{{ release.previous.version }}..HEAD
+    {% endif -%}
+{%- endfor -%}
+"""
+# remove the leading and trailing whitespace from the templates
+trim = true
+
+[git]
+# parse the commits based on https://www.conventionalcommits.org
+conventional_commits = true
+# filter out the commits that are not following the conventional commits format
+filter_unconventional = false
+# process each line of a commit as an individual commit
+split_commits = false
+# regex for preprocessing the commit messages
+commit_preprocessors = [
+  # remove issue numbers from commits
+  { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "" },
+]
+# regex for parsing and grouping commits
+commit_parsers = [
+  { message = "^[a|A]dd", group = "<!-- 1 -->:sparkles: Added" },
+  { message = "^[c|C]hange", group = "<!-- 2 -->:construction_worker: Changed" },
+  { message = "^[f|F]ix", group = "<!-- 3 -->:bug: Bug Fixes" },
+  { message = "^[r|R]emove", group = "<!-- 4 -->:fire: Removed" },
+  { message = "^[d|D]rop", group = "<!-- 4 -->:fire: Removed" },
+  { message = "^[d|D]oc", group = "<!-- 5 -->:books: Documentation" },
+  { message = "^[t|T]est", group = "<!-- 6 -->:white_check_mark: Testing" },
+  { message = "^[c|C]hore", group = "<!-- 7 -->:wrench: Miscellaneous" },
+  { message = "^[c|C]i", group = "<!-- 7 -->️:wrench: Miscellaneous" },
+  { message = "^[m|M]isc", group = "<!-- 7 -->:wrench: Miscellaneous" },
+  { message = "^[d|D]eps", group = "<!-- 8 -->:ship: Dependencies" },
+]
+# filter out the commits that are not matched by commit parsers
+filter_commits = true
+# sort the tags topologically
+topo_order = false
+# sort the commits inside sections by oldest/newest order
+sort_commits = "oldest"


### PR DESCRIPTION
**What:**  
Replaced Pontos-based changelog generation with git-cliff in release workflows.

**Why:**  
To standardize and automate changelog generation, and remove the Pontos dependency.

**How:**  
- Updated release workflows to use git-cliff.
- Removed Pontos references and config files.
- Verified changelog output and workflow execution.

**Checklist:**  
-  Pontos removed
-  git-cliff added & tested
-  Docs updated

JIRA: [DOS-371](https://jira.greenbone.net/browse/DOS-371)